### PR TITLE
make converter's input window clickable

### DIFF
--- a/Sources/Hop/ConvertWindowView.swift
+++ b/Sources/Hop/ConvertWindowView.swift
@@ -119,16 +119,23 @@ struct ConvertWindowView: View {
     // MARK: - Drop zone
 
     private var dropZone: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "arrow.down.doc")
-                .font(.system(size: 20))
-                .foregroundStyle(targeted ? Theme.editing : Theme.textTertiary)
-            Text(t(.convDrop))
-                .font(Theme.mono(11))
-                .foregroundStyle(targeted ? Theme.editing : Theme.textTertiary)
+        // Also a browse button: the same batch entry point as a Finder drag
+        // or ⌘V, reached with a click for anyone who'd rather pick files from
+        // an Open panel than drag them.
+        Button(action: openFilePicker) {
+            VStack(spacing: 8) {
+                Image(systemName: "arrow.down.doc")
+                    .font(.system(size: 20))
+                    .foregroundStyle(targeted ? Theme.editing : Theme.textTertiary)
+                Text(t(.convDrop))
+                    .font(Theme.mono(11))
+                    .foregroundStyle(targeted ? Theme.editing : Theme.textTertiary)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 160)
+            .contentShape(Rectangle())
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 160)
+        .buttonStyle(.plain)
         .background(Theme.rowBg, in: RoundedRectangle(cornerRadius: 10))
         .overlay(
             RoundedRectangle(cornerRadius: 10)
@@ -137,6 +144,7 @@ struct ConvertWindowView: View {
                     style: StrokeStyle(lineWidth: 1, dash: [5, 4])
                 )
         )
+        .hoverHighlight(10)
         .snapshotAwareDrop(of: [.fileURL], isTargeted: $targeted) { providers in
             Task {
                 var urls: [URL] = []
@@ -149,6 +157,17 @@ struct ConvertWindowView: View {
             }
             return true
         }
+    }
+
+    /// Same picker shape as a Finder drag: files or whole folders (expanded by
+    /// `addToBatch`, exactly like a dropped folder), any number of them.
+    private func openFilePicker() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = true
+        guard panel.runModal() == .OK else { return }
+        model.converter.addToBatch(panel.urls)
     }
 
     private func loadFileURL(_ provider: NSItemProvider) async -> URL? {


### PR DESCRIPTION
## Summary
- The converter window's drop zone now also acts as a click target: clicking it opens a standard macOS Open panel (files or whole folders, multiple selection) and feeds the picked URLs through the same `addToBatch` entry point a Finder drag already uses.
- Adds a hover cursor/highlight to the zone so it reads as clickable, consistent with other clickable rows in the app.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — all existing tests pass (no automated test added for this change; it's AppKit/SwiftUI glue, consistent with how every other `NSOpenPanel` call site in this codebase is handled — untested, verified manually)
- [ ] Manual click-through in the running app to confirm the Open panel appears and selected files land in the batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)